### PR TITLE
:sparkles: Implements Add for AudioSample

### DIFF
--- a/src/audio.rs
+++ b/src/audio.rs
@@ -1,6 +1,7 @@
 use futures::Stream;
+use std::ops::Add;
 
-#[derive(Copy, Clone, Debug)]
+#[derive(Copy, Clone, Debug, Default)]
 pub struct AudioSample {
     pub sample: i16,
 }
@@ -11,9 +12,11 @@ impl AudioSample {
     }
 }
 
-impl Default for AudioSample {
-    fn default() -> Self {
-        AudioSample { sample: 0 }
+impl Add for AudioSample {
+    type Output = Self;
+
+    fn add(self, other: Self) -> Self {
+        Self::new(self.sample + other.sample)
     }
 }
 
@@ -64,7 +67,6 @@ impl PartialEq for AudioBuffer {
         self.samples == other.samples
     }
 }
-
 
 struct AudioStream {}
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -6,7 +6,7 @@ mod wav;
 mod samples;
 mod config;
 
-#[allow(dead_code)] 
+#[allow(dead_code)]
 mod audio;
 
 mod mix;
@@ -14,7 +14,7 @@ mod mix;
 use mix::mix;
 use futures_core::stream::Stream;
 use async_mp3::read_mp3_file_to_stream;
-use async_stream::{stream, try_stream};
+use async_stream::{ stream, try_stream };
 use async_wav::write_audio_stream_to_wav_file;
 use futures_util::StreamExt;
 use std::pin::Pin;
@@ -25,35 +25,25 @@ async fn main() {
     let daniel = read_mp3_file_to_stream("stub-data/test1.mp3").await;
     let len = read_mp3_file_to_stream("stub-data/test2.mp3").await;
 
-    let mixed_stream = {
-        let mut daniel_stream = Box::pin(daniel.fuse());
-        let mut len_stream = Box::pin(len.fuse());
+    let mut daniel_stream = Box::pin(daniel.fuse());
+    let mut len_stream = Box::pin(len.fuse());
 
-        let mixed_stream = stream! {
-            loop {
-                let daniel_sample = daniel_stream.next().await;
-                let len_sample = len_stream.next().await;
-                
-                if daniel_sample.is_none() && len_sample.is_none() {
-                    break;
-                }
+    let mixed_stream = stream! {
+        loop {
+            let daniel_sample = daniel_stream.next().await;
+            let len_sample = len_stream.next().await;
 
-                let mixed = mix(vec![
-                    daniel_sample.unwrap_or_default(),
-                    len_sample.unwrap_or_default()
-                ]);
-
-                yield mixed;
+            if daniel_sample.is_none() && len_sample.is_none() {
+                break;
             }
-        };
 
-        write_audio_stream_to_wav_file(
-            "test-output/mix.wav",
-            mixed_stream,
-            44100,
-            2,
-        ).await;
+            let mixed = daniel_sample.unwrap_or_default() + len_sample.unwrap_or_default();
+
+            yield mixed;
+        }
     };
 
-    let pinned_mixed_stream = Box::pin(mixed_stream);
+    write_audio_stream_to_wav_file("test-output/mix.wav", mixed_stream, 44100, 2).await;
+
+    /* let pinned_mixed_stream = Box::pin(mixed_stream); */
 }


### PR DESCRIPTION
Why make a function for adding, when we can just teach Rust how to add?